### PR TITLE
Removed executable from ignore, added driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,5 @@
-# Created by https://www.toptal.com/developers/gitignore/api/java,maven,visualstudiocode,executable
-# Edit at https://www.toptal.com/developers/gitignore?templates=java,maven,visualstudiocode,executable
-
-### Executable ###
-*.app
-*.bat
-*.cgi
-*.com
-*.exe
-*.gadget
-*.jar
-*.pif
-*.vb
-*.wsf
+# Created by https://www.toptal.com/developers/gitignore/api/java,maven,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,maven,visualstudiocode
 
 ### Java ###
 # Compiled class file
@@ -27,6 +15,7 @@
 .mtj.tmp/
 
 # Package Files #
+*.jar
 *.war
 *.nar
 *.ear
@@ -82,4 +71,7 @@ buildNumber.properties
 # Ignore code-workspaces
 *.code-workspace
 
-# End of https://www.toptal.com/developers/gitignore/api/java,maven,visualstudiocode,executable
+# End of https://www.toptal.com/developers/gitignore/api/java,maven,visualstudiocode
+
+#Driver
+*.exe


### PR DESCRIPTION
We just need to ignore .exe; not all of the file extensions provided by gitignore.io for Executable